### PR TITLE
[MAS] New dark mode

### DIFF
--- a/Source/mas/theme/comfy_ui/button/hover_bg_dk.svg
+++ b/Source/mas/theme/comfy_ui/button/hover_bg_dk.svg
@@ -6,10 +6,10 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="35" height="35">
-    <g fill="CUI_PRM_COLOR(59, 59, 59)" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(61, 41, 50)" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="3">
         <rect x="1.5" y="1.5" width="32" height="32" rx="CUI_BTN_ROUNDING()" />
     </g>
-    <g fill="none" stroke="CUI_PRM_COLOR(193, 90, 131)" stroke-width="1">
+    <g fill="none" stroke="CUI_PRM_COLOR(216, 151, 179)" stroke-width="1">
         <rect x="2.5" y="2.5" width="30" height="30" rx="CUI_BTN_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/button/idle_bg_dk.svg
+++ b/Source/mas/theme/comfy_ui/button/idle_bg_dk.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="35" height="35">
-    <g fill="CUI_PRM_COLOR(27, 27, 27)" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(28, 26, 30)" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="3">
         <rect x="1.5" y="1.5" width="32" height="32" rx="CUI_BTN_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/button/insensitive_bg_dk.svg
+++ b/Source/mas/theme/comfy_ui/button/insensitive_bg_dk.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="35" height="35">
-    <g fill="CUI_PRM_COLOR(27, 27, 27)" stroke="CUI_PRM_COLOR(140, 140, 140)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(28, 26, 30)" stroke="CUI_PRM_COLOR(140, 140, 140)" stroke-width="3">
         <rect x="1.5" y="1.5" width="32" height="32" rx="CUI_BTN_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/definitions.rpy
+++ b/Source/mas/theme/comfy_ui/definitions.rpy
@@ -24,19 +24,19 @@ define comfy_ui.menu_font_kerning = 0.0
 define comfy_ui.menu_title.font_size      = 38
 define comfy_ui.menu_title.light.color    = "CUI_SCD_COLOR(255, 255, 255)"
 define comfy_ui.menu_title.light.outlines = [(6, "CUI_SCD_COLOR(187, 85, 153)", 0, 0), (3, "CUI_SCD_COLOR(187, 85, 153)", 2, 2)]
-define comfy_ui.menu_title.dark.color     = "CUI_SCD_COLOR(255, 217, 232)"
-define comfy_ui.menu_title.dark.outlines  = [(6, "CUI_SCD_COLOR(222, 54, 126)", 0, 0), (3, "CUI_SCD_COLOR(222, 54, 126)", 2, 2)]
+define comfy_ui.menu_title.dark.color     = "CUI_SCD_COLOR(250, 235, 241)"
+define comfy_ui.menu_title.dark.outlines  = [(6, "CUI_SCD_COLOR(126, 53, 104)", 0, 0), (3, "CUI_SCD_COLOR(126, 53, 104)", 2, 2)]
 
 define comfy_ui.menu_label.font_size      = 24
 define comfy_ui.menu_label.light.color    = "CUI_SCD_COLOR(255, 255, 255)"
 define comfy_ui.menu_label.light.outlines = [(3, "CUI_SCD_COLOR(187, 85, 153)", 0, 0), (1, "CUI_SCD_COLOR(187, 85, 153)", 1, 1)]
-define comfy_ui.menu_label.dark.color     = "CUI_SCD_COLOR(255, 217, 232)"
-define comfy_ui.menu_label.dark.outlines  = [(3, "CUI_SCD_COLOR(222, 54, 126)", 0, 0), (1, "CUI_SCD_COLOR(222, 54, 126)", 1, 1)]
+define comfy_ui.menu_label.dark.color     = "CUI_SCD_COLOR(250, 235, 241)"
+define comfy_ui.menu_label.dark.outlines  = [(3, "CUI_SCD_COLOR(126, 53, 104)", 0, 0), (1, "CUI_SCD_COLOR(126, 53, 104)", 1, 1)]
 
 define comfy_ui.menu_text.font_size      = 16
 define comfy_ui.menu_text.light.color    = "CUI_SCD_COLOR(56, 56, 56)"
 define comfy_ui.menu_text.light.outlines = []
-define comfy_ui.menu_text.dark.color     = "CUI_SCD_COLOR(253, 91, 162)"
+define comfy_ui.menu_text.dark.color     = "CUI_SCD_COLOR(245, 163, 199)"
 define comfy_ui.menu_text.dark.outlines  = []
 
 define comfy_ui.menu_button_text.font_size                  = 24
@@ -44,10 +44,10 @@ define comfy_ui.menu_button_text.light.color                = "CUI_SCD_COLOR(255
 define comfy_ui.menu_button_text.light.idle_outlines        = [(4, "CUI_SCD_COLOR(187, 85, 153)", 0, 0), (2, "CUI_SCD_COLOR(187, 85, 153)", 2, 2)]
 define comfy_ui.menu_button_text.light.hover_outlines       = [(4, "CUI_SCD_COLOR(255, 170, 204)", 0, 0), (2, "CUI_SCD_COLOR(255, 170, 204)", 2, 2)]
 define comfy_ui.menu_button_text.light.insensitive_outlines = [(4, "CUI_SCD_COLOR(255, 204, 238)", 0, 0), (2, "CUI_SCD_COLOR(255, 204, 238)", 2, 2)]
-define comfy_ui.menu_button_text.dark.color                 = "CUI_SCD_COLOR(255, 217, 232)"
-define comfy_ui.menu_button_text.dark.idle_outlines         = [(4, "CUI_SCD_COLOR(222, 54, 126)", 0, 0), (2, "CUI_SCD_COLOR(222, 54, 126)", 2, 2)]
-define comfy_ui.menu_button_text.dark.hover_outlines        = [(4, "CUI_SCD_COLOR(255, 128, 183)", 0, 0), (2, "CUI_SCD_COLOR(255, 128, 183)", 2, 2)]
-define comfy_ui.menu_button_text.dark.insensitive_outlines  = [(4, "CUI_SCD_COLOR(255, 178, 212)", 0, 0), (2, "CUI_SCD_COLOR(255, 178, 212)", 2, 2)]
+define comfy_ui.menu_button_text.dark.color                 = "CUI_SCD_COLOR(250, 235, 241)"
+define comfy_ui.menu_button_text.dark.idle_outlines         = [(4, "CUI_SCD_COLOR(126, 53, 104)", 0, 0), (2, "CUI_SCD_COLOR(126, 53, 104)", 2, 2)]
+define comfy_ui.menu_button_text.dark.hover_outlines        = [(4, "CUI_SCD_COLOR(201, 105, 172)", 0, 0), (2, "CUI_SCD_COLOR(201, 105, 172)", 2, 2)]
+define comfy_ui.menu_button_text.dark.insensitive_outlines  = [(4, "CUI_SCD_COLOR(186, 120, 166)", 0, 0), (2, "CUI_SCD_COLOR(186, 120, 166)", 2, 2)]
 
 define comfy_ui.music_menu_button_text.font                       = "mod_assets/font/mplus-2p-regular.ttf"
 define comfy_ui.music_menu_button_text.font_kerning               = 0.0
@@ -56,26 +56,26 @@ define comfy_ui.music_menu_button_text.light.color                = "CUI_SCD_COL
 define comfy_ui.music_menu_button_text.light.idle_outlines        = [(3, "CUI_SCD_COLOR(187, 85, 153)", 0, 0), (1, "CUI_SCD_COLOR(187, 85, 153)", 1, 1)]
 define comfy_ui.music_menu_button_text.light.hover_outlines       = [(3, "CUI_SCD_COLOR(255, 170, 204)", 0, 0), (1, "CUI_SCD_COLOR(255, 170, 204)", 1, 1)]
 define comfy_ui.music_menu_button_text.light.insensitive_outlines = [(3, "CUI_SCD_COLOR(255, 204, 238)", 0, 0), (1, "CUI_SCD_COLOR(255, 204, 238)", 1, 1)]
-define comfy_ui.music_menu_button_text.dark.color                 = "CUI_SCD_COLOR(255, 217, 232)"
-define comfy_ui.music_menu_button_text.dark.idle_outlines         = [(3, "CUI_SCD_COLOR(222, 54, 126)", 0, 0), (1, "CUI_SCD_COLOR(222, 54, 126)", 1, 1)]
-define comfy_ui.music_menu_button_text.dark.hover_outlines        = [(3, "CUI_SCD_COLOR(255, 128, 183)", 0, 0), (1, "CUI_SCD_COLOR(255, 128, 183)", 1, 1)]
-define comfy_ui.music_menu_button_text.dark.insensitive_outlines  = [(3, "CUI_SCD_COLOR(255, 178, 212)", 0, 0), (1, "CUI_SCD_COLOR(255, 178, 212)", 1, 1)]
+define comfy_ui.music_menu_button_text.dark.color                 = "CUI_SCD_COLOR(250, 235, 241)"
+define comfy_ui.music_menu_button_text.dark.idle_outlines         = [(3, "CUI_SCD_COLOR(126, 53, 104)", 0, 0), (1, "CUI_SCD_COLOR(126, 53, 104)", 1, 1)]
+define comfy_ui.music_menu_button_text.dark.hover_outlines        = [(3, "CUI_SCD_COLOR(201, 105, 172)", 0, 0), (1, "CUI_SCD_COLOR(201, 105, 172)", 1, 1)]
+define comfy_ui.music_menu_button_text.dark.insensitive_outlines  = [(3, "CUI_SCD_COLOR(186, 120, 166)", 0, 0), (1, "CUI_SCD_COLOR(186, 120, 166)", 1, 1)]
 
 define comfy_ui.confirm_prompt_text.light.color    = "CUI_PRM_COLOR(56, 56, 56)"
 define comfy_ui.confirm_prompt_text.light.outlines = []
-define comfy_ui.confirm_prompt_text.dark.color     = "CUI_PRM_COLOR(253, 91, 162)"
+define comfy_ui.confirm_prompt_text.dark.color     = "CUI_PRM_COLOR(245, 163, 199)"
 define comfy_ui.confirm_prompt_text.dark.outlines  = []
 
 define comfy_ui.dialogue_text.vertical_offset = CUI_DLG_VERT_OFFSET()
 define comfy_ui.dialogue_text.line_spacing    = CUI_DLG_LINE_SPACING()
 define comfy_ui.dialogue_text.color           = "CUI_PRM_COLOR(248, 248, 248)"
-define comfy_ui.dialogue_text.outlines        = [(2, "CUI_PRM_COLOR(40, 40, 40)", 0, 0)]
+define comfy_ui.dialogue_text.outlines        = [(2, "CUI_PRM_COLOR(26, 26, 26)", 0, 0)]
 
 define comfy_ui.history_name.color    = "CUI_PRM_COLOR(248, 248, 248)"
-define comfy_ui.history_name.outlines = [(2, "CUI_PRM_COLOR(40, 40, 40)", 0, 0)]
+define comfy_ui.history_name.outlines = [(2, "CUI_PRM_COLOR(26, 26, 26)", 0, 0)]
 
 define comfy_ui.history_text.color    = "CUI_PRM_COLOR(255, 255, 255)"
-define comfy_ui.history_text.outlines = [(2, "CUI_PRM_COLOR(40, 40, 40)", 0, 0)]
+define comfy_ui.history_text.outlines = [(2, "CUI_PRM_COLOR(26, 26, 26)", 0, 0)]
 
 define comfy_ui.quick_button_text.font_size               = 14
 define comfy_ui.quick_button_text.light.idle_color        = "CUI_SCD_COLOR(85, 34, 34)"
@@ -83,8 +83,8 @@ define comfy_ui.quick_button_text.light.hover_color       = "CUI_SCD_COLOR(255, 
 define comfy_ui.quick_button_text.light.selected_color    = "CUI_SCD_COLOR(255, 255, 255)"
 define comfy_ui.quick_button_text.light.insensitive_color = "CUI_SCD_COLOR(170, 102, 102)"
 define comfy_ui.quick_button_text.light.outlines          = []
-define comfy_ui.quick_button_text.dark.idle_color         = "CUI_SCD_COLOR(255, 170, 153)"
-define comfy_ui.quick_button_text.dark.hover_color        = "CUI_SCD_COLOR(255, 212, 204)"
+define comfy_ui.quick_button_text.dark.idle_color         = "CUI_SCD_COLOR(235, 173, 185)"
+define comfy_ui.quick_button_text.dark.hover_color        = "CUI_SCD_COLOR(252, 232, 236)"
 define comfy_ui.quick_button_text.dark.selected_color     = "CUI_SCD_COLOR(255, 238, 235)"
 define comfy_ui.quick_button_text.dark.insensitive_color  = "CUI_SCD_COLOR(170, 102, 102)"
 define comfy_ui.quick_button_text.dark.outlines           = []
@@ -94,10 +94,10 @@ define comfy_ui.button_text.light.hover_color       = "CUI_PRM_COLOR(255, 170, 1
 define comfy_ui.button_text.light.selected_color    = "CUI_PRM_COLOR(187, 85, 136)"
 define comfy_ui.button_text.light.insensitive_color = "CUI_PRM_COLOR(170, 170, 170, 127)"
 define comfy_ui.button_text.light.outlines          = []
-define comfy_ui.button_text.dark.idle_color         = "CUI_PRM_COLOR(253, 91, 162)"
-define comfy_ui.button_text.dark.hover_color        = "CUI_PRM_COLOR(255, 171, 216)"
+define comfy_ui.button_text.dark.idle_color         = "CUI_PRM_COLOR(245, 163, 199)"
+define comfy_ui.button_text.dark.hover_color        = "CUI_PRM_COLOR(255, 189, 200)"
 define comfy_ui.button_text.dark.selected_color     = "CUI_PRM_COLOR(187, 85, 136)"
-define comfy_ui.button_text.dark.insensitive_color  = "CUI_PRM_COLOR(170, 170, 170, 127)"
+define comfy_ui.button_text.dark.insensitive_color  = "CUI_PRM_COLOR(115, 115, 115, 127)"
 define comfy_ui.button_text.dark.outlines           = []
 
 define comfy_ui.option_button_text.font                    = "CUI_OPTION_FONT()"
@@ -107,17 +107,17 @@ define comfy_ui.option_button_text.light.idle_color        = "CUI_SCD_COLOR(170,
 define comfy_ui.option_button_text.light.hover_color       = "CUI_SCD_COLOR(204, 102, 153)"
 define comfy_ui.option_button_text.light.selected_color    = "CUI_SCD_COLOR(187, 85, 136)"
 define comfy_ui.option_button_text.light.insensitive_color = "CUI_SCD_COLOR(170, 170, 170, 127)"
-define comfy_ui.option_button_text.dark.idle_color         = "CUI_SCD_COLOR(170, 170, 170)"
-define comfy_ui.option_button_text.dark.hover_color        = "CUI_SCD_COLOR(255, 128, 183)"
-define comfy_ui.option_button_text.dark.selected_color     = "CUI_SCD_COLOR(222, 54, 126)"
-define comfy_ui.option_button_text.dark.insensitive_color  = "CUI_SCD_COLOR(170, 170, 170, 127)"
+define comfy_ui.option_button_text.dark.idle_color         = "CUI_SCD_COLOR(115, 115, 115)"
+define comfy_ui.option_button_text.dark.hover_color        = "CUI_SCD_COLOR(230, 153, 186)"
+define comfy_ui.option_button_text.dark.selected_color     = "CUI_SCD_COLOR(209, 123, 157)"
+define comfy_ui.option_button_text.dark.insensitive_color  = "CUI_SCD_COLOR(115, 115, 115, 127)"
 
 define comfy_ui.fancy_check_button.light.idle_background_color     = "CUI_PRM_COLOR(0, 0, 0, 0)"
 define comfy_ui.fancy_check_button.light.hover_background_color    = "CUI_PRM_COLOR(255, 189, 225)"
 define comfy_ui.fancy_check_button.light.selected_background_color = "CUI_PRM_COLOR(255, 189, 225)"
 define comfy_ui.fancy_check_button.dark.idle_background_color      = "CUI_PRM_COLOR(0, 0, 0, 0)"
-define comfy_ui.fancy_check_button.dark.hover_background_color     = "CUI_PRM_COLOR(206, 74, 126)"
-define comfy_ui.fancy_check_button.dark.selected_background_color  = "CUI_PRM_COLOR(206, 74, 126)"
+define comfy_ui.fancy_check_button.dark.hover_background_color     = "CUI_PRM_COLOR(206, 126, 160)"
+define comfy_ui.fancy_check_button.dark.selected_background_color  = "CUI_PRM_COLOR(206, 126, 160)"
 
 define comfy_ui.fancy_check_button_text.font                    = "CUI_OPTION_FONT()"
 define comfy_ui.fancy_check_button_text.font_kerning            = 0.0
@@ -126,8 +126,8 @@ define comfy_ui.fancy_check_button_text.light.idle_color        = "CUI_PRM_COLOR
 define comfy_ui.fancy_check_button_text.light.hover_color       = "CUI_PRM_COLOR(56, 56, 56)"
 define comfy_ui.fancy_check_button_text.light.selected_color    = "CUI_PRM_COLOR(56, 56, 56)"
 define comfy_ui.fancy_check_button_text.dark.idle_color         = "CUI_PRM_COLOR(191, 191, 191)"
-define comfy_ui.fancy_check_button_text.dark.hover_color        = "CUI_PRM_COLOR(255, 170, 153)"
-define comfy_ui.fancy_check_button_text.dark.selected_color     = "CUI_PRM_COLOR(255, 170, 153)"
+define comfy_ui.fancy_check_button_text.dark.hover_color        = "CUI_PRM_COLOR(235, 173, 185)"
+define comfy_ui.fancy_check_button_text.dark.selected_color     = "CUI_PRM_COLOR(235, 173, 185)"
 
 define comfy_ui.button_height_adjustment = CUI_BTN_HEIGHT_ADJUSTMENT()
 

--- a/Source/mas/theme/comfy_ui/replacers/gui/button/choice_dark_hover_background.svg
+++ b/Source/mas/theme/comfy_ui/replacers/gui/button/choice_dark_hover_background.svg
@@ -6,10 +6,10 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="400" height="35">
-    <g fill="CUI_PRM_COLOR(59, 59, 59)" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(61, 41, 50)" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="3">
         <rect x="1.5" y="1.5" width="397" height="32" rx="CUI_BTN_ROUNDING()" />
     </g>
-    <g fill="none" stroke="CUI_PRM_COLOR(193, 90, 131)" stroke-width="1">
+    <g fill="none" stroke="CUI_PRM_COLOR(216, 151, 179)" stroke-width="1">
         <rect x="2.5" y="2.5" width="395" height="30" rx="CUI_BTN_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/gui/button/choice_dark_idle_background.svg
+++ b/Source/mas/theme/comfy_ui/replacers/gui/button/choice_dark_idle_background.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="400" height="35">
-    <g fill="CUI_PRM_COLOR(27, 27, 27)" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(28, 26, 30)" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="3">
         <rect x="1.5" y="1.5" width="397" height="32" rx="CUI_BTN_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/gui/button/scrollable_menu_dark_disable_background.svg
+++ b/Source/mas/theme/comfy_ui/replacers/gui/button/scrollable_menu_dark_disable_background.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="400" height="35">
-    <g fill="CUI_PRM_COLOR(27, 27, 27)" stroke="CUI_PRM_COLOR(140, 140, 140)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(28, 26, 30)" stroke="CUI_PRM_COLOR(140, 140, 140)" stroke-width="3">
         <rect x="1.5" y="1.5" width="397" height="32" rx="CUI_BTN_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/gui/button/scrollable_menu_dark_hover_background.svg
+++ b/Source/mas/theme/comfy_ui/replacers/gui/button/scrollable_menu_dark_hover_background.svg
@@ -6,10 +6,10 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="400" height="35">
-    <g fill="CUI_PRM_COLOR(59, 59, 59)" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(61, 41, 50)" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="3">
         <rect x="1.5" y="1.5" width="397" height="32" rx="CUI_BTN_ROUNDING()" />
     </g>
-    <g fill="none" stroke="CUI_PRM_COLOR(193, 90, 131)" stroke-width="1">
+    <g fill="none" stroke="CUI_PRM_COLOR(216, 151, 179)" stroke-width="1">
         <rect x="2.5" y="2.5" width="395" height="30" rx="CUI_BTN_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/gui/button/scrollable_menu_dark_idle_background.svg
+++ b/Source/mas/theme/comfy_ui/replacers/gui/button/scrollable_menu_dark_idle_background.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="400" height="35">
-    <g fill="CUI_PRM_COLOR(27, 27, 27)" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(28, 26, 30)" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="3">
         <rect x="1.5" y="1.5" width="397" height="32" rx="CUI_BTN_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/gui/button/twopane_scrollable_menu_dark_hover_background.svg
+++ b/Source/mas/theme/comfy_ui/replacers/gui/button/twopane_scrollable_menu_dark_hover_background.svg
@@ -6,10 +6,10 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="400" height="35">
-    <g fill="CUI_PRM_COLOR(59, 59, 59)" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(61, 41, 50)" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="3">
         <rect x="1.5" y="1.5" width="397" height="32" rx="CUI_BTN_ROUNDING()" />
     </g>
-    <g fill="none" stroke="CUI_PRM_COLOR(193, 90, 131)" stroke-width="1">
+    <g fill="none" stroke="CUI_PRM_COLOR(216, 151, 179)" stroke-width="1">
         <rect x="2.5" y="2.5" width="395" height="30" rx="CUI_BTN_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/gui/button/twopane_scrollable_menu_dark_idle_background.svg
+++ b/Source/mas/theme/comfy_ui/replacers/gui/button/twopane_scrollable_menu_dark_idle_background.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="400" height="35">
-    <g fill="CUI_PRM_COLOR(27, 27, 27)" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(28, 26, 30)" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="3">
         <rect x="1.5" y="1.5" width="397" height="32" rx="CUI_BTN_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/gui/frame_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/gui/frame_d.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="600" height="250">
-    <g fill="CUI_PRM_COLOR(27, 27, 27)" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="4">
+    <g fill="CUI_PRM_COLOR(28, 26, 30)" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="4">
         <rect x="2" y="2" width="596" height="246" rx="CUI_FRM_ROUNDING()" />
     </g>
     <g fill="none" stroke="CUI_PRM_COLOR(85, 44, 61)" stroke-width="1">

--- a/Source/mas/theme/comfy_ui/replacers/gui/menu_bg_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/gui/menu_bg_d.svg
@@ -23,12 +23,12 @@
             <path d="M 0.5 0.05 l 0.1469463 0.29774575 l 0.32858195 0.0477458 l -0.23776413 0.23176273 l 0.0561285 0.32725426 l -0.29389262 -0.15450851 l -0.29389264 0.15450849 l 0.0561285 -0.32725424 l -0.23776412 -0.23176276 l 0.32858194 -0.0477457 Z" />
         </svg>
         <pattern id="pattern" x="-40" y="-140" width="200" height="200" patternUnits="userSpaceOnUse">
-            <g fill="CUI_PRM_COLOR(206, 74, 126)" stroke-linejoin="round">
+            <g fill="CUI_PRM_COLOR(58, 39, 47)" stroke-linejoin="round">
                 <use xlink:href="#CUI_MNU_PTSHAPE()" transform="translate(0 0) scale(80)" />
                 <use xlink:href="#CUI_MNU_PTSHAPE()" transform="translate(100 100) scale(80)" />
             </g>
         </pattern>
     </defs>
-    <rect x="0" y="0" width="1380" height="1320" fill="CUI_PRM_COLOR(27, 27, 27)" />
+    <rect x="0" y="0" width="1380" height="1320" fill="CUI_PRM_COLOR(31, 31, 31)" />
     <rect x="0" y="0" width="1680" height="1620" fill="url(#pattern)" />
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/gui/namebox_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/gui/namebox_d.svg
@@ -8,9 +8,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="168" height="39">
     <defs>
         <linearGradient id="fillGradient" x1="50%" y1="0%" x2="50%" y2="100%" gradientUnits="userSpaceOnUse">
-            <stop offset="0%" style="stop-color: CUI_PRM_COLOR(27, 27, 27)" />
-            <stop offset="82.5%" style="stop-color: CUI_PRM_COLOR(27, 27, 27)" />
-            <stop offset="100%" style="stop-color: CUI_PRM_COLOR(16, 16, 16)" />
+            <stop offset="0%" style="stop-color: CUI_PRM_COLOR(40, 36, 38)" />
+            <stop offset="82.5%" style="stop-color: CUI_PRM_COLOR(40, 36, 38)" />
+            <stop offset="100%" style="stop-color: CUI_PRM_COLOR(24, 22, 23)" />
         </linearGradient>
     </defs>
     <g fill="url(#fillGradient)" fill-opacity="1.0">

--- a/Source/mas/theme/comfy_ui/replacers/gui/overlay/game_menu_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/gui/overlay/game_menu_d.svg
@@ -7,7 +7,7 @@
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1280" height="720">
     <rect x="0" y="0" width="1280" height="720" fill="CUI_PRM_COLOR(0, 0, 0)" fill-opacity="0.5" />
-    <g fill="CUI_PRM_COLOR(27, 27, 27)" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="30">
+    <g fill="CUI_PRM_COLOR(28, 26, 30)" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="30">
         <circle cx="-995" cy="360" r="1290" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/gui/overlay/main_menu_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/gui/overlay/main_menu_d.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1280" height="720">
-    <g fill="CUI_PRM_COLOR(27, 27, 27)" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="30">
+    <g fill="CUI_PRM_COLOR(28, 26, 30)" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="30">
         <circle cx="-995" cy="360" r="1290" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/gui/textbox_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/gui/textbox_d.svg
@@ -41,13 +41,17 @@
             <path d="M 0.5 0.05 l 0.1469463 0.29774575 l 0.32858195 0.0477458 l -0.23776413 0.23176273 l 0.0561285 0.32725426 l -0.29389262 -0.15450851 l -0.29389264 0.15450849 l 0.0561285 -0.32725424 l -0.23776412 -0.23176276 l 0.32858194 -0.0477457 Z" />
         </svg>
         <pattern id="pattern" x="-10" y="-10" width="46.5" height="46.5" patternUnits="userSpaceOnUse">
-            <g fill="CUI_PRM_COLOR(161, 45, 101)" stroke-linejoin="round">
+            <g fill="CUI_PRM_COLOR(127, 52, 84)" stroke-linejoin="round">
                 <use xlink:href="#CUI_DLG_PTSHAPE()" transform="translate(2 2) scale(18.5)" />
                 <use xlink:href="#CUI_DLG_PTSHAPE()" transform="translate(25.25 25.25) scale(18.5)" />
             </g>
         </pattern>
+        <linearGradient id="backgroundGradient" x1="50%" y1="0%" x2="50%" y2="100%">
+            <stop offset="0%" style="stop-color: CUI_PRM_COLOR(147, 67, 102)" />
+            <stop offset="100%" style="stop-color: CUI_PRM_COLOR(140, 64, 97)" />
+        </linearGradient>
         <pattern id="backgroundMain" width="816" height="146" patternUnits="userSpaceOnUse">
-            <rect width="816" height="146" fill="CUI_PRM_COLOR(192, 75, 122)" />
+            <rect width="816" height="146" fill="url(#backgroundGradient)" />
             <rect width="816" height="146" fill="url(#pattern)" />
             <circle cx="408" cy="2338" r="2250" fill="url(#shineGradient)" mask="url(#shineFadeMask)" />
         </pattern>
@@ -55,7 +59,7 @@
             <rect width="816" height="146" fill="url(#backgroundMain)" mask="url(#backgroundFadeMask)" />
         </pattern>
     </defs>
-    <g fill="url(#backgroundFinal)" stroke="CUI_PRM_COLOR(27, 27, 27)" stroke-width="3">
+    <g fill="url(#backgroundFinal)" stroke="CUI_PRM_COLOR(43, 23, 32)" stroke-width="3">
         <rect x="1.5" y="1.5" width="813" height="143" rx="CUI_DLG_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/gui/textbox_monika_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/gui/textbox_monika_d.svg
@@ -41,13 +41,17 @@
             <path d="M 0.5 0.05 l 0.1469463 0.29774575 l 0.32858195 0.0477458 l -0.23776413 0.23176273 l 0.0561285 0.32725426 l -0.29389262 -0.15450851 l -0.29389264 0.15450849 l 0.0561285 -0.32725424 l -0.23776412 -0.23176276 l 0.32858194 -0.0477457 Z" />
         </svg>
         <pattern id="pattern" x="-10" y="-10" width="46.5" height="46.5" patternUnits="userSpaceOnUse">
-            <g fill="CUI_PRM_COLOR(161, 45, 101)" stroke-linejoin="round">
+            <g fill="CUI_PRM_COLOR(127, 52, 84)" stroke-linejoin="round">
                 <use xlink:href="#CUI_DLG_PTSHAPE()" transform="translate(2 2) scale(18.5)" />
                 <use xlink:href="#CUI_DLG_PTSHAPE()" transform="translate(25.25 25.25) scale(18.5)" />
             </g>
         </pattern>
+        <linearGradient id="backgroundGradient" x1="50%" y1="0%" x2="50%" y2="100%">
+            <stop offset="0%" style="stop-color: CUI_PRM_COLOR(147, 67, 102)" />
+            <stop offset="100%" style="stop-color: CUI_PRM_COLOR(140, 64, 97)" />
+        </linearGradient>
         <pattern id="backgroundMain" width="816" height="146" patternUnits="userSpaceOnUse">
-            <rect width="816" height="146" fill="CUI_PRM_COLOR(192, 75, 122)" />
+            <rect width="816" height="146" fill="url(#backgroundGradient)" />
             <rect width="816" height="146" fill="url(#pattern)" />
             <circle cx="408" cy="2338" r="2250" fill="url(#shineGradient)" mask="url(#shineFadeMask)" />
         </pattern>
@@ -55,7 +59,7 @@
             <rect width="816" height="146" fill="url(#backgroundMain)" mask="url(#backgroundFadeMask)" />
         </pattern>
     </defs>
-    <g fill="url(#backgroundFinal)" stroke="CUI_PRM_COLOR(27, 27, 27)" stroke-width="3" transform="translate(42 0)">
+    <g fill="url(#backgroundFinal)" stroke="CUI_PRM_COLOR(43, 23, 32)" stroke-width="3" transform="translate(42 0)">
         <rect x="1.5" y="1.5" width="813" height="143" rx="CUI_DLG_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/mod_assets/buttons/checkbox/check_fg_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/mod_assets/buttons/checkbox/check_fg_d.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="31" height="34">
-    <g fill="none" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="1">
+    <g fill="none" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="1">
         <rect x="6.5" y="8.5" width="21" height="21" rx="CUI_BTN_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/mod_assets/buttons/checkbox/selected_check_fg_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/mod_assets/buttons/checkbox/selected_check_fg_d.svg
@@ -6,10 +6,10 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="31" height="34">
-    <g fill="none" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="1">
+    <g fill="none" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="1">
         <rect x="6.5" y="8.5" width="21" height="21" rx="CUI_BTN_ROUNDING()" />
     </g>
-    <g fill="CUI_SCD_COLOR(255, 170, 153)" stroke="CUI_SCD_COLOR(255, 170, 153)" stroke-width="1">
+    <g fill="CUI_SCD_COLOR(235, 173, 185)" stroke="CUI_SCD_COLOR(235, 173, 185)" stroke-width="1">
         <rect x="8.5" y="10.5" width="17" height="17" rx="CUI_BTN_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/mod_assets/buttons/generic/hover_bg_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/mod_assets/buttons/generic/hover_bg_d.svg
@@ -6,10 +6,10 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="35" height="35">
-    <g fill="CUI_PRM_COLOR(59, 59, 59)" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(61, 41, 50)" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="3">
         <rect x="1.5" y="1.5" width="32" height="32" rx="CUI_BTN_ROUNDING()" />
     </g>
-    <g fill="none" stroke="CUI_PRM_COLOR(193, 90, 131)" stroke-width="1">
+    <g fill="none" stroke="CUI_PRM_COLOR(216, 151, 179)" stroke-width="1">
         <rect x="2.5" y="2.5" width="30" height="30" rx="CUI_BTN_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/mod_assets/buttons/generic/idle_bg_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/mod_assets/buttons/generic/idle_bg_d.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="35" height="35">
-    <g fill="CUI_PRM_COLOR(27, 27, 27)" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(28, 26, 30)" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="3">
         <rect x="1.5" y="1.5" width="32" height="32" rx="CUI_BTN_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/mod_assets/buttons/generic/insensitive_bg_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/mod_assets/buttons/generic/insensitive_bg_d.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="35" height="35">
-    <g fill="CUI_PRM_COLOR(27, 27, 27)" stroke="CUI_PRM_COLOR(140, 140, 140)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(28, 26, 30)" stroke="CUI_PRM_COLOR(140, 140, 140)" stroke-width="3">
         <rect x="1.5" y="1.5" width="32" height="32" rx="CUI_BTN_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/mod_assets/buttons/generic/selected_bg_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/mod_assets/buttons/generic/selected_bg_d.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="35" height="35">
-    <g fill="CUI_PRM_COLOR(27, 27, 27)" stroke="CUI_PRM_COLOR(255, 170, 153)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(28, 26, 30)" stroke="CUI_PRM_COLOR(235, 173, 185)" stroke-width="3">
         <rect x="1.5" y="1.5" width="32" height="32" rx="CUI_BTN_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/mod_assets/buttons/squares/square_disabled_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/mod_assets/buttons/squares/square_disabled_d.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="35" height="35">
-    <g fill="CUI_PRM_COLOR(27, 27, 27)" stroke="CUI_PRM_COLOR(140, 140, 140)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(28, 26, 30)" stroke="CUI_PRM_COLOR(140, 140, 140)" stroke-width="3">
         <rect x="1.5" y="1.5" width="32" height="32" rx="CUI_BTN_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/mod_assets/buttons/squares/square_hover_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/mod_assets/buttons/squares/square_hover_d.svg
@@ -6,10 +6,10 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="35" height="35">
-    <g fill="CUI_PRM_COLOR(59, 59, 59)" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(61, 41, 50)" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="3">
         <rect x="1.5" y="1.5" width="32" height="32" rx="CUI_BTN_ROUNDING()" />
     </g>
-    <g fill="none" stroke="CUI_PRM_COLOR(193, 90, 131)" stroke-width="1">
+    <g fill="none" stroke="CUI_PRM_COLOR(216, 151, 179)" stroke-width="1">
         <rect x="2.5" y="2.5" width="30" height="30" rx="CUI_BTN_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/mod_assets/buttons/squares/square_idle_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/mod_assets/buttons/squares/square_idle_d.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="35" height="35">
-    <g fill="CUI_PRM_COLOR(27, 27, 27)" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(28, 26, 30)" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="3">
         <rect x="1.5" y="1.5" width="32" height="32" rx="CUI_BTN_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/mod_assets/frames/black70_pinkborder100_2px_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/mod_assets/frames/black70_pinkborder100_2px_d.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="35" height="35">
-    <g fill="CUI_PRM_COLOR(0, 0, 0)" fill-opacity="0.7" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="2">
+    <g fill="CUI_PRM_COLOR(0, 0, 0)" fill-opacity="0.7" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="2">
         <rect x="1" y="1" width="33" height="33" rx="CUI_FRM_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/mod_assets/frames/black70_pinkborder100_5px_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/mod_assets/frames/black70_pinkborder100_5px_d.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="35" height="35">
-    <g fill="CUI_PRM_COLOR(0, 0, 0)" fill-opacity="0.7" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="5">
+    <g fill="CUI_PRM_COLOR(0, 0, 0)" fill-opacity="0.7" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="5">
         <rect x="2.5" y="2.5" width="30" height="30" rx="CUI_FRM_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/mod_assets/frames/black70_pinkborder100_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/mod_assets/frames/black70_pinkborder100_d.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="35" height="35">
-    <g fill="CUI_PRM_COLOR(0, 0, 0)" fill-opacity="0.7" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(0, 0, 0)" fill-opacity="0.7" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="3">
         <rect x="1.5" y="1.5" width="32" height="32" rx="CUI_FRM_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/mod_assets/frames/modebar_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/mod_assets/frames/modebar_d.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="70" height="490">
-    <g fill="CUI_PRM_COLOR(0, 0, 0)" fill-opacity="0.7" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="2">
+    <g fill="CUI_PRM_COLOR(0, 0, 0)" fill-opacity="0.7" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="2">
         <rect x="1" y="1" width="68" height="488" rx="CUI_FRM_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/mod_assets/frames/selector_overlay_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/mod_assets/frames/selector_overlay_d.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="180" height="180">
-    <g fill="CUI_PRM_COLOR(255, 255, 255)" fill-opacity="0.0" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(255, 255, 255)" fill-opacity="0.0" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="3">
         <rect x="1.5" y="-8.5" width="177" height="187" rx="CUI_FRM_ROUNDING()" />
         <line x1="3" y1="1.5" x2="177" y2="1.5" />
     </g>

--- a/Source/mas/theme/comfy_ui/replacers/mod_assets/frames/selector_top_frame_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/mod_assets/frames/selector_top_frame_d.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="180" height="38">
-    <g fill="CUI_PRM_COLOR(27, 27, 27)" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(28, 26, 30)" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="3">
         <rect x="1.5" y="1.5" width="177" height="48" rx="CUI_FRM_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/mod_assets/frames/selector_top_frame_disabled_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/mod_assets/frames/selector_top_frame_disabled_d.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="180" height="38">
-    <g fill="CUI_PRM_COLOR(27, 27, 27)" stroke="CUI_PRM_COLOR(140, 140, 140)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(28, 26, 30)" stroke="CUI_PRM_COLOR(140, 140, 140)" stroke-width="3">
         <rect x="1.5" y="1.5" width="177" height="48" rx="CUI_FRM_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/mod_assets/frames/selector_top_frame_selected_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/mod_assets/frames/selector_top_frame_selected_d.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="180" height="38">
-    <g fill="CUI_PRM_COLOR(59, 59, 59)" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(59, 59, 59)" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="3">
         <rect x="1.5" y="1.5" width="177" height="48" rx="CUI_FRM_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/mod_assets/frames/trans_pink2pxborder100_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/mod_assets/frames/trans_pink2pxborder100_d.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="35" height="35">
-    <g fill="CUI_PRM_COLOR(255, 255, 255)" fill-opacity="0.0" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="2">
+    <g fill="CUI_PRM_COLOR(255, 255, 255)" fill-opacity="0.0" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="2">
         <rect x="1" y="1" width="33" height="33" rx="CUI_FRM_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/mod_assets/hkb_disabled_background_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/mod_assets/hkb_disabled_background_d.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="120" height="35">
-    <g fill="CUI_PRM_COLOR(27, 27, 27)" stroke="CUI_PRM_COLOR(140, 140, 140)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(28, 26, 30)" stroke="CUI_PRM_COLOR(140, 140, 140)" stroke-width="3">
         <rect x="1.5" y="1.5" width="117" height="32" rx="CUI_BTN_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/mod_assets/hkb_hover_background_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/mod_assets/hkb_hover_background_d.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="120" height="35">
-    <g fill="CUI_PRM_COLOR(59, 59, 59)" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(61, 41, 50)" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="3">
         <rect x="1.5" y="1.5" width="117" height="32" rx="CUI_BTN_ROUNDING()" />
     </g>
     <g fill="none" stroke="CUI_PRM_COLOR(181, 89, 129)" stroke-width="1">

--- a/Source/mas/theme/comfy_ui/replacers/mod_assets/hkb_idle_background_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/mod_assets/hkb_idle_background_d.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="120" height="35">
-    <g fill="CUI_PRM_COLOR(27, 27, 27)" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(28, 26, 30)" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="3">
         <rect x="1.5" y="1.5" width="117" height="32" rx="CUI_BTN_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/mod_assets/island_hover_background_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/mod_assets/island_hover_background_d.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="200" height="35">
-    <g fill="CUI_PRM_COLOR(59, 59, 59)" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(61, 41, 50)" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="3">
         <rect x="1.5" y="1.5" width="197" height="32" rx="CUI_BTN_ROUNDING()" />
     </g>
     <g fill="none" stroke="CUI_PRM_COLOR(181, 89, 129)" stroke-width="1">

--- a/Source/mas/theme/comfy_ui/replacers/mod_assets/island_idle_background_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/mod_assets/island_idle_background_d.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="200" height="35">
-    <g fill="CUI_PRM_COLOR(27, 27, 27)" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(28, 26, 30)" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="3">
         <rect x="1.5" y="1.5" width="197" height="32" rx="CUI_BTN_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/mod_assets/music_menu_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/mod_assets/music_menu_d.svg
@@ -7,7 +7,7 @@
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1280" height="720">
     <rect x="0" y="0" width="1280" height="720" fill="CUI_PRM_COLOR(0, 0, 0)" fill-opacity="0.8" />
-    <g fill="CUI_PRM_COLOR(27, 27, 27)" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="30">
+    <g fill="CUI_PRM_COLOR(28, 26, 30)" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="30">
         <circle cx="-836" cy="360" r="1290" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/replacers/mod_assets/updateavailable_d.svg
+++ b/Source/mas/theme/comfy_ui/replacers/mod_assets/updateavailable_d.svg
@@ -6,10 +6,10 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="639" height="35">
-    <g fill="CUI_SCD_COLOR(27, 27, 27)" opacity="0.75">
+    <g fill="CUI_SCD_COLOR(28, 26, 30)" opacity="0.75">
         <rect x="0" y="0" width="639" height="35" />
     </g>
-    <g fill="CUI_PRM_COLOR(253, 91, 162)" font-family="Halogen" font-size="24px">
+    <g fill="CUI_PRM_COLOR(245, 163, 199)" font-family="Halogen" font-size="24px">
         <text x="11" y="25">Update available! Click Update Version in settings to update</text>
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/scrollbar/horizontal_bar_dk.svg
+++ b/Source/mas/theme/comfy_ui/scrollbar/horizontal_bar_dk.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="716" height="18">
-    <g stroke="CUI_PRM_COLOR(27, 27, 27)" stroke-linecap="round" stroke-width="4">
+    <g stroke="CUI_PRM_COLOR(28, 26, 30)" stroke-linecap="round" stroke-width="4">
         <line x1="6" y1="9" x2="710" y2="9" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/scrollbar/horizontal_hover_thumb_dk.svg
+++ b/Source/mas/theme/comfy_ui/scrollbar/horizontal_hover_thumb_dk.svg
@@ -6,10 +6,10 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="716" height="18">
-    <g fill="CUI_PRM_COLOR(59, 59, 59)" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(61, 41, 50)" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="3">
         <rect x="1.5" y="3.5" width="713" height="11" rx="CUI_BTN_ROUNDING()" />
     </g>
-    <g fill="none" stroke="CUI_PRM_COLOR(193, 90, 131)" stroke-width="1">
+    <g fill="none" stroke="CUI_PRM_COLOR(216, 151, 179)" stroke-width="1">
         <rect x="2.5" y="4.5" width="711" height="9" rx="CUI_BTN_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/scrollbar/horizontal_idle_thumb_dk.svg
+++ b/Source/mas/theme/comfy_ui/scrollbar/horizontal_idle_thumb_dk.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="716" height="18">
-    <g fill="CUI_PRM_COLOR(27, 27, 27)" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(28, 26, 30)" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="3">
         <rect x="1.5" y="3.5" width="713" height="11" rx="CUI_BTN_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/scrollbar/vertical_bar_dk.svg
+++ b/Source/mas/theme/comfy_ui/scrollbar/vertical_bar_dk.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="18" height="716">
-    <g stroke="CUI_PRM_COLOR(27, 27, 27)" stroke-linecap="round" stroke-width="4">
+    <g stroke="CUI_PRM_COLOR(28, 26, 30)" stroke-linecap="round" stroke-width="4">
         <line x1="9" y1="6" x2="9" y2="710" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/scrollbar/vertical_hover_thumb_dk.svg
+++ b/Source/mas/theme/comfy_ui/scrollbar/vertical_hover_thumb_dk.svg
@@ -6,10 +6,10 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="18" height="716">
-    <g fill="CUI_PRM_COLOR(59, 59, 59)" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(61, 41, 50)" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="3">
         <rect x="3.5" y="1.5" width="11" height="713" rx="CUI_BTN_ROUNDING()" />
     </g>
-    <g fill="none" stroke="CUI_PRM_COLOR(193, 90, 131)" stroke-width="1">
+    <g fill="none" stroke="CUI_PRM_COLOR(216, 151, 179)" stroke-width="1">
         <rect x="4.5" y="2.5" width="9" height="711" rx="CUI_BTN_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/scrollbar/vertical_idle_thumb_dk.svg
+++ b/Source/mas/theme/comfy_ui/scrollbar/vertical_idle_thumb_dk.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="18" height="716">
-    <g fill="CUI_PRM_COLOR(27, 27, 27)" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(28, 26, 30)" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="3">
         <rect x="3.5" y="1.5" width="11" height="713" rx="CUI_BTN_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/slider/horizontal_hover_thumb_dk.svg
+++ b/Source/mas/theme/comfy_ui/slider/horizontal_hover_thumb_dk.svg
@@ -6,10 +6,10 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="16" height="17">
-    <g fill="CUI_PRM_COLOR(59, 59, 59)" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(61, 41, 50)" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="3">
         <rect x="1.5" y="1.5" width="13" height="14" rx="CUI_BTN_ROUNDING()" />
     </g>
-    <g fill="none" stroke="CUI_PRM_COLOR(193, 90, 131)" stroke-width="1">
+    <g fill="none" stroke="CUI_PRM_COLOR(216, 151, 179)" stroke-width="1">
         <rect x="2.5" y="2.5" width="11" height="12" rx="CUI_BTN_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/slider/horizontal_idle_thumb_dk.svg
+++ b/Source/mas/theme/comfy_ui/slider/horizontal_idle_thumb_dk.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="16" height="17">
-    <g fill="CUI_PRM_COLOR(27, 27, 27)" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(28, 26, 30)" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="3">
         <rect x="1.5" y="1.5" width="13" height="14" rx="CUI_BTN_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/slider/vertical_hover_thumb_dk.svg
+++ b/Source/mas/theme/comfy_ui/slider/vertical_hover_thumb_dk.svg
@@ -6,10 +6,10 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="17" height="16">
-    <g fill="CUI_PRM_COLOR(59, 59, 59)" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(61, 41, 50)" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="3">
         <rect x="1.5" y="1.5" width="14" height="13" rx="CUI_BTN_ROUNDING()" />
     </g>
-    <g fill="none" stroke="CUI_PRM_COLOR(193, 90, 131)" stroke-width="1">
+    <g fill="none" stroke="CUI_PRM_COLOR(216, 151, 179)" stroke-width="1">
         <rect x="2.5" y="2.5" width="12" height="11" rx="CUI_BTN_ROUNDING()" />
     </g>
 </svg>

--- a/Source/mas/theme/comfy_ui/slider/vertical_idle_thumb_dk.svg
+++ b/Source/mas/theme/comfy_ui/slider/vertical_idle_thumb_dk.svg
@@ -6,7 +6,7 @@
 =
 =============================================================================-->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="17" height="16">
-    <g fill="CUI_PRM_COLOR(27, 27, 27)" stroke="CUI_PRM_COLOR(206, 74, 126)" stroke-width="3">
+    <g fill="CUI_PRM_COLOR(28, 26, 30)" stroke="CUI_PRM_COLOR(206, 126, 160)" stroke-width="3">
         <rect x="1.5" y="1.5" width="14" height="13" rx="CUI_BTN_ROUNDING()" />
     </g>
 </svg>


### PR DESCRIPTION
I'm still not quite satisfied with current result, but it definitely reduces an eye strain in the long run.

---
<table>
  <tr>
    <th></th>
    <th>Light</th>
    <th>Dark (new)</th>
    <th>Dark (old)</th>
  </tr>
  <tr>
    <th>In-game</th>
    <td><img src="https://user-images.githubusercontent.com/5585984/81910350-811d2e00-95d4-11ea-8860-e652b89dd139.png"></td>
    <td><img src="https://user-images.githubusercontent.com/5585984/81910305-7498d580-95d4-11ea-9735-ff1abcfe75b1.png"></td>
    <td><img src="https://user-images.githubusercontent.com/5585984/81910367-89756900-95d4-11ea-873c-13fa66be2a10.png"></td>
  </tr>
  <tr>
    <th>Menu</th>
    <td><img src="https://user-images.githubusercontent.com/5585984/81910363-87130f00-95d4-11ea-90dc-5beec7061a5a.png"></td>
    <td><img src="https://user-images.githubusercontent.com/5585984/81910326-7a8eb680-95d4-11ea-8cdc-865efc79bae1.png"></td>
    <td><img src="https://user-images.githubusercontent.com/5585984/81910380-8e3a1d00-95d4-11ea-9dd5-c676e4ea6ca3.png"></td>
  </tr>
</table>

---
To do:
- [x] Update definitions:
  - [x] `comfy_ui.fancy_check_button`
  - [x] `comfy_ui.fancy_check_button_text`
- [x] Update assets:
  - [x] `mod_assets/updateavailable_d`
  - [x] `mod_assets/buttons/checkbox/check_fg_d`
  - [x] `mod_assets/buttons/checkbox/insensitive_check_fg_d`
  - [x] `mod_assets/buttons/checkbox/selected_check_fg_d`
  - [x] `mod_assets/buttons/checkbox/selected_insensitive_check_fg_d`
  - [x] `mod_assets/buttons/checkbox/selected_bg_d`
- [x] Check in-game